### PR TITLE
fix: Works セクションの rootage-ses-quiz を rootage に修正

### DIFF
--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -99,7 +99,8 @@ def build_readme() -> str:
 
 ### Works
 
-- [SES面談対策クイズ](https://github.com/mohadayo/rootage-ses-quiz) - SES企業向け面談対策アプリ (Go)
+- [rootage](https://github.com/mohadayo/rootage) - SES企業向け新人エンジニア育成アプリ (Go + Vue 3 + PostgreSQL)
+  <br>*[ルーテイジ株式会社](https://www.rootage.co.jp/)様より受注・納品。許可を得てソースコードを公開しています。*
 
 ---
 


### PR DESCRIPTION
## 変更概要
- scripts/update_readme.py の Works セクションを修正
- rootage-ses-quiz → rootage に変更
- 説明文・受注・公開許可の注記を追加

## 対応Issue番号
Closes #3

## 動作確認手順
1. python scripts/update_readme.py を実行
2. README.md の Works セクションに rootage が正しく表示されることを確認