### PR TITLE
fix(ci): add contents: write permission so workflow can push README updates

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Root Cause

The `update-readme` workflow fetches blog and Qiita posts then runs:
```bash
git diff --quiet README.md || (git add README.md && git commit -m "..." && git push)
```

Without an explicit `permissions` block, the `GITHUB_TOKEN` defaults to read-only access in this repository. The `git push` step therefore fails with a 403 permission error.

## Fix

Added `permissions: contents: write` to the `update` job so the workflow token can commit and push changes to `README.md`.

## Impact

Minimal — no code changed, only the workflow job permissions.