### PR TITLE
ci-auto-fix: add id-token: write permission

### DIFF
--- a/.github/workflows/ci-auto-fix.yml
+++ b/.github/workflows/ci-auto-fix.yml
@@ -15,6 +15,7 @@ jobs:
       contents: write
       pull-requests: write
       actions: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- `claude-code-action@v1` requires an OIDC token for GitHub authentication
- Without `id-token: write`, the action fails before reaching the prompt step

## Background
On 2026-05-05 the `Update README` schedule run timed out waiting for a runner (`cancelled` after 15 min), which fired `CI Auto-Fix`. That run failed with:

```
Could not fetch an OIDC token. Did you remember to add 'id-token: write' to your workflow permissions?
```

So the auto-fix path is currently inert.

## Change
Add a single permission line in `.github/workflows/ci-auto-fix.yml`:

```yaml
id-token: write
```

## Test plan
- [ ] Merge this PR
- [ ] Wait for the next `Update README` failure (or trigger one) and confirm `CI Auto-Fix` reaches the action body instead of failing at OIDC token fetch