### PR TITLE
Products セクションを上位3件に絞る

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@
 
 - [盆栽ブランチ](https://bonsai-branch.pages.dev) - 盆栽を育てるように、gitの主要操作を覚えるパズルゲーム (React + TypeScript)
 
-- [東京、どこに住む？](https://where-can-i-live.vercel.app) - 生活スタイルから逆算して、上京者が住むべき駅を断定してくれるサービス (Next.js + tRPC + MapLibre)
-
-- [Lantern](https://lantern-snowy.vercel.app) - あなたの苦悩を過去に乗り越えた人と話せる。お悩み相談マッチングアプリ (Next.js + Supabase)
-
-- [KAGEBUNSHIN](https://kagebunshin-beryl.vercel.app) - 仕事の資料を放り込むだけ。あなたを支える専属AIパートナー (Next.js + Supabase)
-
 ---
 
 ### Blog Posts


### PR DESCRIPTION
## 概要

プロフィール README の Products が6件まで増えていたため、先頭3件のみ残す。

**残す**
- rootage-app
- 珈琲専門店 詩季
- 盆栽ブランチ

**削除**
- 東京、どこに住む？
- Lantern
- KAGEBUNSHIN

## 確認したこと

- 差分は README.md の Products 3項目(＋区切りの空行)のみ。Tech Stack / Blog Posts / Qiita Posts / Last updated は無変更
- `scripts/update_readme.py` は `<!-- blog -->` / `<!-- qiita -->` タグ間とタイムスタンプのみを置換するため、Products は日次の Update README で復活しない
- 削除した3件のリポジトリ自体はそのまま(README の掲載を外すだけ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K2gUNqjBHLj3L8jWSzDtr