### PR TITLE
Tech Stack に GCP・Cloudflare・Supabase を追加し Nuxt を外す

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ### Tech Stack
 
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=python,go,ts,nextjs,nuxtjs,fastapi,django,docker,aws,githubactions&perline=5&theme=light" alt="Tech Stack" />
+  <img src="https://skillicons.dev/icons?i=python,go,ts,nextjs,fastapi,django,docker,aws,gcp,cloudflare,supabase,githubactions&perline=6&theme=light" alt="Tech Stack" />
 </p>
 
 ---


### PR DESCRIPTION
## 変更内容

Tech Stack の skillicons を更新する。

| | |
|---|---|
| 外す | `nuxtjs` |
| 足す | `gcp` `cloudflare` `supabase` |

```diff
- ?i=python,go,ts,nextjs,nuxtjs,fastapi,django,docker,aws,githubactions&perline=5
+ ?i=python,go,ts,nextjs,fastapi,django,docker,aws,gcp,cloudflare,supabase,githubactions&perline=6
```

`nuxtjs` は、公開リポジトリの言語構成と手元にある非公開リポジトリの `package.json` を確認した範囲で使用箇所が見つからなかったため外した。

## perline を 5 → 6 に変えた理由

アイコンが10個から12個になり、`perline=5` のままだと 5 + 5 + 2 で最後の行が2個だけになる。6個×2行にすると収まりがよく、並びも次のように分かれる。

```
1行目  Python  Go  TypeScript  Next.js  FastAPI  Django      … 言語・フレームワーク
2行目  Docker  AWS  GCP  Cloudflare  Supabase  GitHub Actions … インフラ・サービス
```

## 確認したこと

- 変更後の URL を実際に取得し、`viewBox="0 0 1756 556"`（6列×2行）で12個すべてが描画されることを確認
- skillicons は存在しないアイコン名に対して 256 バイトの空 SVG を返す仕様のため、`gcp` `cloudflare` `supabase` がいずれもプレースホルダではなく実体を返すことを個別に確認済み
- ブラウザで表示し、12個が意図した順序で並ぶことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K2gUNqjBHLj3L8jWSzDtr
